### PR TITLE
Added ELAN to CRF pipeline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# Interlinear glossing with CRF
+## Additional Pipeline Scripts
+
+This repo now includes conversion scripts to support more data formats for interlinear glossing.
+
+### Scripts Added:
+- `elan_to_pipeline.py`: Converts ELAN exports to CRF-friendly format.
+- `pipeline_to_elan.py`: Converts CRF results back into ELAN-readable format.
+- `toolbox_to_pipeline.py`: Converts Toolbox-formatted IGT data to CRF pipeline format.
+
+These scripts are meant to support the extended glossing needs described in the paper.

--- a/elan_to_crf.py
+++ b/elan_to_crf.py
@@ -1,0 +1,36 @@
+# elan_to_crf.py
+from pympi.Elan import Eaf
+import argparse
+
+def convert_eaf_to_crf(eaf_path, output_path):
+    eaf = Eaf(eaf_path)
+    tiers = eaf.get_tier_names()
+    
+    # Example: pick tiers manually (edit as needed)
+    transcription_tier = 'transcription'
+    morph_tier = 'morphemes'
+    gloss_tier = 'gloss'
+
+    with open(output_path, 'w', encoding='utf-8') as out_f:
+        for annotation in eaf.get_annotation_data_for_tier(transcription_tier):
+            start, end, text = annotation
+            morphs = eaf.get_annotation_data_between_times(morph_tier, start, end)
+            glosses = eaf.get_annotation_data_between_times(gloss_tier, start, end)
+            
+            # Ensure aligned counts
+            if len(morphs) != len(glosses):
+                continue
+            
+            for m, g in zip(morphs, glosses):
+                _, _, morph = m
+                _, _, gloss = g
+                out_f.write(f"{morph}\t{gloss}\n")
+            out_f.write("\n")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('eaf_file', help='Path to input EAF file')
+    parser.add_argument('output_file', help='Path to output CRF format file')
+    args = parser.parse_args()
+    
+    convert_eaf_to_crf(args.eaf_file, args.output_file)

--- a/elan_to_pipeline.py
+++ b/elan_to_pipeline.py
@@ -1,0 +1,23 @@
+# Extract tokens and glosses from ELAN .eaf file
+import pympi
+
+eaf = pympi.Elan.Eaf("input.eaf")
+token_data = eaf.get_annotation_data_for_tier("tokens")
+gloss_data = eaf.get_annotation_data_for_tier("gloss")
+
+def index_by_time(data):
+    return {(start, end): text for start, end, text in data}
+
+token_map = index_by_time(token_data)
+gloss_map = index_by_time(gloss_data)
+
+with open("pipeline_input.txt", "w", encoding="utf-8") as out:
+    for key in sorted(token_map.keys()):
+        tokens = token_map.get(key, "").split('\t')
+        glosses = gloss_map.get(key, "").split('\t')
+        if len(tokens) != len(glosses):
+            print(f"Warning: mismatch at {key}, skipping.")
+            continue
+        for t, g in zip(tokens, glosses):
+            out.write(f"{t}\t{g}\n")
+        out.write("\n")

--- a/pipeline_to_elan.py
+++ b/pipeline_to_elan.py
@@ -1,0 +1,27 @@
+# Convert pipeline output (predictions) into an ELAN .eaf file
+import pympi
+
+eaf = pympi.Elan.Eaf()
+eaf.add_tier('tokens')
+eaf.add_tier('gloss')
+
+with open("pipeline_output.txt", "r", encoding="utf-8") as f:
+    block = []
+    time = 0
+    step = 1000
+    for line in f:
+        if line.strip() == "":
+            if block:
+                start, end = time, time + step
+                tokens = [w for w, _ in block]
+                glosses = [g for _, g in block]
+                eaf.add_annotation('tokens', start, end, '\t'.join(tokens))
+                eaf.add_annotation('gloss', start, end, '\t'.join(glosses))
+                block = []
+                time += step
+        else:
+            w, g = line.strip().split('\t')
+            block.append((w, g))
+
+eaf.to_file("predicted.eaf")
+print("ELAN file saved: predicted.eaf")

--- a/toolbox_to_pipeline.py
+++ b/toolbox_to_pipeline.py
@@ -1,0 +1,21 @@
+# Convert \t, \m, \g lines into SIGMORPHON format
+import re
+
+with open("toolbox_input.txt", "r", encoding="utf-8") as f:
+    content = f.read()
+
+blocks = re.split(r'\n(?=\\t)', content.strip())
+
+with open("pipeline_input.txt", "w", encoding="utf-8") as out:
+    for block in blocks:
+        lines = block.strip().split("\n")
+        m_line = next((l[3:].strip() for l in lines if l.startswith("\\m")), "")
+        g_line = next((l[3:].strip() for l in lines if l.startswith("\\g")), "")
+        tokens = m_line.split()
+        glosses = g_line.split()
+        if len(tokens) != len(glosses):
+            print("Warning: token/gloss mismatch, skipping block.")
+            continue
+        for tok, gloss in zip(tokens, glosses):
+            out.write(f"{tok}\t{gloss}\n")
+        out.write("\n")


### PR DESCRIPTION
This pull request adds a script `elan_to_crf.py` for converting ELAN files to the format used by the CRF glossing pipeline. It is meant to support data used in the current paper.

Authored by: @Hiwasan (please add name to the paper authors list).